### PR TITLE
Render template

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -7,6 +7,15 @@ export default class App extends Application {
   modulePrefix = config.modulePrefix;
   podModulePrefix = config.podModulePrefix;
   Resolver = Resolver;
+  engines = {
+    editEngine: {
+      dependencies: {
+        services: [
+          'content'
+        ]
+      }
+    }
+  };
 }
 
 loadInitializers(App, config.modulePrefix);

--- a/app/router.js
+++ b/app/router.js
@@ -8,9 +8,13 @@ export default class Router extends EmberRouter {
 
 Router.map(function() {
   this.route('datasets', function() {
-    this.route('dataset', { path: '/:dataset_id' });
+    this.route('dataset', { path: '/:dataset_id' }, function () {
+      // this.mount('edit-engine', { path: '/edit' }); // if we do it this way we don't get params, we do get the resolved model but we are in the outlet of datasets.dataset
+    });
+    this.mount('edit-engine', { path: '/:dataset_id/edit' }); // if we do it this way we get params.dataset_id, but we do not get the resolved model, and we are not in our datasets.dataset outle
   });
   this.route('documents', function() {
     this.route('document', { path: '/:document_id' });
+    this.mount('edit-engine', { path: '/:document_id/edit' });
   });
 });

--- a/app/routes/datasets/dataset.js
+++ b/app/routes/datasets/dataset.js
@@ -1,12 +1,11 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class DatasetsDatasetRoute extends Route {
+  @service content;
 
   async model(params) {
-    return {
-      id: params.dataset_id,
-      title: 'this is the dataset title'
-    }
+    return this.content.fetchDataset(params.dataset_id);
   }
 
 }

--- a/app/routes/documents/document.js
+++ b/app/routes/documents/document.js
@@ -1,12 +1,11 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class DocumentsDocumentRoute extends Route {
+  @service content;
 
   async model(params) {
-    return {
-      id: params.document_id,
-      title: 'this is the document title'
-    }
+    return this.content.fetchDocument(params.document_id);
   }
 
 }

--- a/app/services/content.js
+++ b/app/services/content.js
@@ -1,0 +1,21 @@
+import Service from '@ember/service';
+
+export default class ContentService extends Service {
+
+  fetchDataset (id) {
+    return {
+      id,
+      title: `this is the title for dataset_id ${id}`,
+      type: 'dataset'
+    }
+  }
+
+  fetchDocument (id) {
+    return {
+      id,
+      title: `this is the title for document_id ${id}`,
+      type: 'document'
+    }
+  }
+
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,1 +1,3 @@
+<h1>APPLICATION TEMPLATE</h1>
+<hr>
 {{outlet}}

--- a/app/templates/datasets.hbs
+++ b/app/templates/datasets.hbs
@@ -1,2 +1,15 @@
-<h1>DATASETS ROUTE</h1>
+<h1>DATASETS TEMPLATE</h1>
+
+<div>
+  <LinkTo @route="datasets.datasets" @model="abc123">
+    abc123
+  </LinkTo>
+  <br>
+  <LinkTo @route="datasets.datasets" @model="def456">
+    def456
+  </LinkTo>
+</div>
+
+<hr>
+
 {{outlet}}

--- a/app/templates/datasets/dataset.hbs
+++ b/app/templates/datasets/dataset.hbs
@@ -1,4 +1,4 @@
-<h2>DATASET ROUTE</h2>
+<h2>DATASET TEMPLATE</h2>
 
 <dl>
     <dt>id:</dt>
@@ -7,4 +7,4 @@
     <dd>{{this.model.title}}</dd>
 </dl>
 
-{{outlet}}
+<LinkTo @route="datasets.edit-engine" @model={{this.model.id}}>edit</LinkTo>

--- a/app/templates/datasets/dataset.hbs
+++ b/app/templates/datasets/dataset.hbs
@@ -6,3 +6,5 @@
     <dt>title:</dt>
     <dd>{{this.model.title}}</dd>
 </dl>
+
+{{outlet}}

--- a/app/templates/documents.hbs
+++ b/app/templates/documents.hbs
@@ -1,2 +1,15 @@
-<h1>DOCUMENTS ROUTE</h1>
+<h1>DOCUMENTS TEMPLATE</h1>
+
+<div>
+  <LinkTo @route="documents.document" @model="abc123">
+    abc123
+  </LinkTo>
+  <br>
+  <LinkTo @route="documents.document" @model="def456">
+    def456
+  </LinkTo>
+</div>
+
+<hr>
+
 {{outlet}}

--- a/app/templates/documents/document.hbs
+++ b/app/templates/documents/document.hbs
@@ -1,4 +1,4 @@
-<h2>DOCUMENT ROUTE</h2>
+<h2>DOCUMENT TEMPLATE</h2>
 
 <dl>
     <dt>id:</dt>
@@ -6,3 +6,5 @@
     <dt>title:</dt>
     <dd>{{this.model.title}}</dd>
 </dl>
+
+<LinkTo @route="datasets.edit-engine" @model={{this.model.id}}>edit</LinkTo>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,0 +1,7 @@
+<LinkTo @route="datasets">
+  Datasets
+</LinkTo>
+<br>
+<LinkTo @route="documents">
+  Documents
+</LinkTo>

--- a/lib/edit-engine/addon/controllers/dataset.js
+++ b/lib/edit-engine/addon/controllers/dataset.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+
+export default class DatasetController extends Controller {
+
+  get modelString() {
+    return JSON.stringify(this.model, null, 2)
+  }
+
+}

--- a/lib/edit-engine/addon/controllers/document.js
+++ b/lib/edit-engine/addon/controllers/document.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+
+export default class DocumentController extends Controller {
+
+  get modelString() {
+    return JSON.stringify(this.model, null, 2)
+  }
+
+}

--- a/lib/edit-engine/addon/engine.js
+++ b/lib/edit-engine/addon/engine.js
@@ -1,0 +1,22 @@
+import Engine from 'ember-engines/engine';
+import loadInitializers from 'ember-load-initializers';
+import Resolver from './resolver';
+import config from './config/environment';
+
+const { modulePrefix } = config;
+
+const hash = {
+  modulePrefix,
+  Resolver,
+  dependencies: {
+    services: [
+      'content'
+    ]
+  }
+};
+
+const Eng = Engine.extend(hash);
+
+loadInitializers(Eng, modulePrefix);
+
+export default Eng;

--- a/lib/edit-engine/addon/resolver.js
+++ b/lib/edit-engine/addon/resolver.js
@@ -1,0 +1,3 @@
+import Resolver from 'ember-resolver';
+
+export default Resolver;

--- a/lib/edit-engine/addon/routes.js
+++ b/lib/edit-engine/addon/routes.js
@@ -1,0 +1,4 @@
+import buildRoutes from 'ember-engines/routes';
+
+export default buildRoutes(function() {
+});

--- a/lib/edit-engine/addon/routes/application.js
+++ b/lib/edit-engine/addon/routes/application.js
@@ -1,0 +1,28 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default class ApplicationRoute extends Route {
+  @service content;
+
+  model(params) {
+    let model;
+    if (params.dataset_id) {
+      model = this.content.fetchDataset(params.dataset_id);
+    }
+    if (params.document_id) {
+      model = this.content.fetchDocument(params.document_id)
+    }
+    return model;
+  }
+
+  renderTemplate(applicationController, model) {
+    const template = model.type;
+    const controller = this.controllerFor(model.type);
+    this.render(template, {
+      // into: 'application',
+      controller,
+      model
+    });
+  }
+
+}

--- a/lib/edit-engine/addon/routes/application.js
+++ b/lib/edit-engine/addon/routes/application.js
@@ -19,7 +19,7 @@ export default class ApplicationRoute extends Route {
     const template = model.type;
     const controller = this.controllerFor(model.type);
     this.render(template, {
-      // into: 'application',
+      into: 'application',
       controller,
       model
     });

--- a/lib/edit-engine/addon/templates/application.hbs
+++ b/lib/edit-engine/addon/templates/application.hbs
@@ -1,0 +1,2 @@
+edit engine application route
+{{outlet}}

--- a/lib/edit-engine/addon/templates/application.hbs
+++ b/lib/edit-engine/addon/templates/application.hbs
@@ -1,2 +1,2 @@
-edit engine application route
+edit engine application template
 {{outlet}}

--- a/lib/edit-engine/addon/templates/dataset.hbs
+++ b/lib/edit-engine/addon/templates/dataset.hbs
@@ -1,0 +1,3 @@
+edit-engine/dataset
+<pre><code>{{this.modelString}}</code></pre>
+{{outlet}}

--- a/lib/edit-engine/addon/templates/dataset.hbs
+++ b/lib/edit-engine/addon/templates/dataset.hbs
@@ -1,3 +1,3 @@
-edit-engine/dataset
+<h3>edit-engine/dataset template</h3>
 <pre><code>{{this.modelString}}</code></pre>
 {{outlet}}

--- a/lib/edit-engine/addon/templates/document.hbs
+++ b/lib/edit-engine/addon/templates/document.hbs
@@ -1,3 +1,2 @@
-edit-engine/document
-<pre><code>{{this.modelString}}</code></pre>
+<h3>edit-engine/document template</h3><pre><code>{{this.modelString}}</code></pre>
 {{outlet}}

--- a/lib/edit-engine/addon/templates/document.hbs
+++ b/lib/edit-engine/addon/templates/document.hbs
@@ -1,0 +1,3 @@
+edit-engine/document
+<pre><code>{{this.modelString}}</code></pre>
+{{outlet}}

--- a/lib/edit-engine/app/controllers/dataset.js
+++ b/lib/edit-engine/app/controllers/dataset.js
@@ -1,0 +1,1 @@
+export { default } from 'edit-engine/controllers/dataset';

--- a/lib/edit-engine/app/controllers/document.js
+++ b/lib/edit-engine/app/controllers/document.js
@@ -1,0 +1,1 @@
+export { default } from 'edit-engine/controllers/document';

--- a/lib/edit-engine/app/routes/dataset.js
+++ b/lib/edit-engine/app/routes/dataset.js
@@ -1,0 +1,1 @@
+export { default } from 'edit-engine/routes/dataset';

--- a/lib/edit-engine/app/routes/document.js
+++ b/lib/edit-engine/app/routes/document.js
@@ -1,0 +1,1 @@
+export { default } from 'edit-engine/routes/document';

--- a/lib/edit-engine/app/templates/dataset.js
+++ b/lib/edit-engine/app/templates/dataset.js
@@ -1,0 +1,1 @@
+export { default } from 'edit-engine/templates/dataset';

--- a/lib/edit-engine/app/templates/document.js
+++ b/lib/edit-engine/app/templates/document.js
@@ -1,0 +1,1 @@
+export { default } from 'edit-engine/templates/document';

--- a/lib/edit-engine/config/environment.js
+++ b/lib/edit-engine/config/environment.js
@@ -1,0 +1,11 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = function(environment) {
+  let ENV = {
+    modulePrefix: 'edit-engine',
+    environment
+  };
+
+  return ENV;
+};

--- a/lib/edit-engine/index.js
+++ b/lib/edit-engine/index.js
@@ -1,0 +1,16 @@
+/* eslint-env node */
+'use strict';
+
+const EngineAddon = require('ember-engines/lib/engine-addon');
+
+module.exports = EngineAddon.extend({
+  name: 'edit-engine',
+
+  lazyLoading: Object.freeze({
+    enabled: false
+  }),
+
+  isDevelopingAddon() {
+    return true;
+  }
+});

--- a/lib/edit-engine/package.json
+++ b/lib/edit-engine/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "edit-engine",
+  "keywords": [
+    "ember-addon",
+    "ember-engine"
+  ],
+  "dependencies": {
+    "ember-cli-htmlbars": "*",
+    "ember-cli-babel": "*"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2841,6 +2841,12 @@
       "integrity": "sha512-Lja2xYuuf2B3knEsga8ShbOdsfNOtzT73GyJmZyY7eGl2+ajOqrs8yM5ze0fsSoYwvA6bw7/Qr7OZ7PEEmYwWg==",
       "dev": true
     },
+    "@types/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
@@ -3793,6 +3799,12 @@
       "requires": {
         "babel-runtime": "^6.22.0"
       }
+    },
+    "babel-plugin-compact-reexports": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-compact-reexports/-/babel-plugin-compact-reexports-1.1.0.tgz",
+      "integrity": "sha512-+KgjNJ5yMeZzJxYZdLEy9m82m92aL7FLvNJcK6dYJbW06t+UTpFJ2FVSs35zMfURcPnrQELYhLG4VC+kt/4gvw==",
+      "dev": true
     },
     "babel-plugin-debug-macros": {
       "version": "0.3.3",
@@ -5027,6 +5039,23 @@
         "tree-sync": "^1.2.2"
       }
     },
+    "broccoli-dependency-funnel": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/broccoli-dependency-funnel/-/broccoli-dependency-funnel-2.1.2.tgz",
+      "integrity": "sha512-k6b0OnNuRcUnJ9TXA0o6RvqXOkTQ6APKoLsZeMJHAe/YjLjE1uTlfw4Z88GfGmi8gwtLHdnkrhBoJ7YdIkcVZA==",
+      "dev": true,
+      "requires": {
+        "broccoli-plugin": "^1.3.1",
+        "fs-tree-diff": "^0.5.9",
+        "heimdalljs": "^0.2.5",
+        "heimdalljs-logger": "^0.1.9",
+        "mkdirp": "^0.5.1",
+        "mr-dep-walk": "^1.4.0",
+        "path-posix": "^1.0.0",
+        "rimraf": "^2.6.2",
+        "symlink-or-copy": "^1.2.0"
+      }
+    },
     "broccoli-file-creator": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz",
@@ -5516,6 +5545,127 @@
         "lodash.template": "^4.4.0",
         "rimraf": "^2.6.2",
         "walk-sync": "^0.3.3"
+      }
+    },
+    "broccoli-test-helper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-test-helper/-/broccoli-test-helper-2.0.0.tgz",
+      "integrity": "sha512-TKwh8dBT+RcxKEG+vAoaRRhZsCMwZIHPZbCzBNCA0nUi1aoFB/LVosqwMC6H9Ipe06FxY5hpQxDLFbnBMdUPsA==",
+      "dev": true,
+      "requires": {
+        "@types/tmp": "^0.0.33",
+        "broccoli": "^2.0.0",
+        "fixturify": "^0.3.2",
+        "fs-tree-diff": "^0.5.9",
+        "tmp": "^0.0.33",
+        "walk-sync": "^0.3.3"
+      },
+      "dependencies": {
+        "broccoli": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/broccoli/-/broccoli-2.3.0.tgz",
+          "integrity": "sha512-TeYMYlCGFK8EGk4Wce1G1uU3i52+YxRqP3WPOVDojC1zUk+Gi40wHBzUT2fncQZDl26dmCQMNugtHKjvUpcGQg==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-info": "1.1.0",
+            "broccoli-slow-trees": "^3.0.1",
+            "broccoli-source": "^1.1.0",
+            "commander": "^2.15.1",
+            "connect": "^3.6.6",
+            "esm": "^3.2.4",
+            "findup-sync": "^2.0.0",
+            "handlebars": "^4.0.11",
+            "heimdalljs": "^0.2.6",
+            "heimdalljs-logger": "^0.1.9",
+            "mime-types": "^2.1.19",
+            "promise.prototype.finally": "^3.1.0",
+            "resolve-path": "^1.4.0",
+            "rimraf": "^2.6.2",
+            "sane": "^4.0.0",
+            "tmp": "0.0.33",
+            "tree-sync": "^1.2.2",
+            "underscore.string": "^3.2.2",
+            "watch-detector": "^0.1.0"
+          }
+        },
+        "broccoli-node-info": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz",
+          "integrity": "sha1-OqLjHgflvbUW3SUhT3xFuhxFlBI=",
+          "dev": true
+        },
+        "findup-sync": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "dev": true,
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
+          }
+        },
+        "fixturify": {
+          "version": "0.3.4",
+          "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-0.3.4.tgz",
+          "integrity": "sha512-Gx+KSB25b6gMc4bf7UFRTA85uE0iZR+RYur0JHh6dg4AGBh0EksOv4FCHyM7XpGmiJO7Bc7oV7vxENQBT+2WEQ==",
+          "dev": true,
+          "requires": {
+            "fs-extra": "^0.30.0",
+            "matcher-collection": "^1.0.4"
+          }
+        },
+        "fs-extra": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "rsvp": {
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+          "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+          "dev": true
+        },
+        "watch-detector": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/watch-detector/-/watch-detector-0.1.0.tgz",
+          "integrity": "sha512-vfzMMfpjQc88xjETwl2HuE6PjEuxCBeyC4bQmqrHrofdfYWi/4mEJklYbNgSzpqM9PxubsiPIrE5SZ1FDyiQ2w==",
+          "dev": true,
+          "requires": {
+            "heimdalljs-logger": "^0.1.9",
+            "quick-temp": "^0.1.8",
+            "rsvp": "^4.7.0",
+            "semver": "^5.4.1",
+            "silent-error": "^1.1.0"
+          }
+        }
       }
     },
     "broccoli-uglify-sourcemap": {
@@ -7266,6 +7416,34 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
           "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
           "dev": true
+        }
+      }
+    },
+    "ember-asset-loader": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/ember-asset-loader/-/ember-asset-loader-0.6.1.tgz",
+      "integrity": "sha512-e2zafQJBMLhzl69caTG/+mQMH20uMHYrm7KcmdbmnX0oY2dZ48bhm0Wh1SPLXS/6G2T9NsNMWX6J2pVSnI+xyA==",
+      "dev": true,
+      "requires": {
+        "broccoli-caching-writer": "^3.0.3",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "ember-cli-babel": "^7.5.0",
+        "fs-extra": "^7.0.1",
+        "object-assign": "^4.1.0",
+        "walk-sync": "^1.1.3"
+      },
+      "dependencies": {
+        "walk-sync": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
+          "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^1.1.1"
+          }
         }
       }
     },
@@ -9050,6 +9228,32 @@
             "matcher-collection": "^2.0.0"
           }
         }
+      }
+    },
+    "ember-engines": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/ember-engines/-/ember-engines-0.8.5.tgz",
+      "integrity": "sha512-ezbH+OBjGSa6fPSHqpNSVGdz1k9rHpV7tiP1SaEkbHwfuikl28TRY8Am6fgdnL8K6pP5qcSrSl+yUIaGULqOSg==",
+      "dev": true,
+      "requires": {
+        "amd-name-resolver": "1.3.1",
+        "babel-plugin-compact-reexports": "^1.1.0",
+        "broccoli-babel-transpiler": "^7.2.0",
+        "broccoli-concat": "^3.7.3",
+        "broccoli-debug": "^0.6.5",
+        "broccoli-dependency-funnel": "^2.1.2",
+        "broccoli-file-creator": "^2.1.1",
+        "broccoli-funnel": "^2.0.2",
+        "broccoli-merge-trees": "^3.0.2",
+        "broccoli-test-helper": "^2.0.0",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "ember-asset-loader": "^0.6.1",
+        "ember-cli-babel": "^7.11.1",
+        "ember-cli-htmlbars": "^4.0.0",
+        "ember-cli-preprocess-registry": "^3.3.0",
+        "ember-cli-string-utils": "^1.1.0",
+        "ember-cli-version-checker": "^3.1.3",
+        "lodash": "^4.17.11"
       }
     },
     "ember-export-application-global": {
@@ -13271,6 +13475,15 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "leek": {
       "version": "0.0.24",
       "resolved": "https://registry.npmjs.org/leek/-/leek-0.0.24.tgz",
@@ -14144,6 +14357,54 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
+      }
+    },
+    "mr-dep-walk": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mr-dep-walk/-/mr-dep-walk-1.4.0.tgz",
+      "integrity": "sha512-UaDUqkLsd0ep3jAx2+A7BIpfw8wKxhthDj3yPNLBnevipK1CUFJJiz24jRVLw18q7R2aEiRq13WwUBlnwfbQqQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.1.1",
+        "amd-name-resolver": "^0.0.6",
+        "fs-extra": "^3.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+          "dev": true
+        },
+        "amd-name-resolver": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-0.0.6.tgz",
+          "integrity": "sha1-0+S6Lfyqsdggwb6d6UfGeCjP5ZU=",
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "^1.0.1"
+          }
+        },
+        "fs-extra": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^3.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        }
       }
     },
     "ms": {
@@ -15378,6 +15639,17 @@
       "resolved": "https://registry.npmjs.org/promise.hash.helper/-/promise.hash.helper-1.0.7.tgz",
       "integrity": "sha512-0qhWYyCV9TYDMSooYw1fShIb7R6hsWYja7JLqbeb1MvHqDTvP/uy/R1RsyVqDi6GCiHOI4G5p2Hpr3IA+/l/+Q==",
       "dev": true
+    },
+    "promise.prototype.finally": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.2.tgz",
+      "integrity": "sha512-A2HuJWl2opDH0EafgdjwEw7HysI8ff/n4lW4QEVBCUXFk9QeGecBWv0Deph0UmLe3tTNYegz8MOjsVuE6SMoJA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.0",
+        "function-bind": "^1.1.1"
+      }
     },
     "proxy-addr": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
     "ember-data": "~3.17.0",
+    "ember-engines": "^0.8.5",
     "ember-export-application-global": "^2.0.1",
     "ember-fetch": "^7.0.1",
     "ember-load-initializers": "^2.1.1",
@@ -56,5 +57,10 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/edit-engine"
+    ]
   }
 }

--- a/tests/unit/controllers/dataset-test.js
+++ b/tests/unit/controllers/dataset-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | dataset', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:dataset');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/controllers/document-test.js
+++ b/tests/unit/controllers/document-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | document', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:document');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/routes/dataset-test.js
+++ b/tests/unit/routes/dataset-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | dataset', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:dataset');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/document-test.js
+++ b/tests/unit/routes/document-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | document', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:document');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/services/content-test.js
+++ b/tests/unit/services/content-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | content', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:content');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
This one defines the routes at the root level. This means that when we land at the edit-engine application route model hook:
1. params.dataset_id or params.document_id is defined so we can fetch it.
1. we do not get the resolved model because we are not in a route nested under, for example, datasets:dataset_id
1. We are not "inside" the template nesting. We will by default be rendering into the application template